### PR TITLE
build: Add Flag to Use Oracle JDK on Codefire

### DIFF
--- a/core/main.mk
+++ b/core/main.mk
@@ -179,9 +179,11 @@ endif
 # For Java 1.7, we require OpenJDK on linux and Oracle JDK on Mac OS.
 # For Java 1.6, we require Oracle for all host OSes.
 requires_openjdk := false
+ifneq ($(BUILDING_ON_CODEFIRE),true)
 ifeq ($(LEGACY_USE_JAVA6),)
 ifeq ($(HOST_OS), linux)
 requires_openjdk := true
+endif
 endif
 endif
 


### PR DESCRIPTION
* Works just fine, easier to deploy Oracle JDK Locally

Signed-off-by: Paul Keith <javelinanddart@gmail.com>